### PR TITLE
[codex] cache tray scroll suppression

### DIFF
--- a/Sources/KClip/Views/ScrollViewSuppressionView.swift
+++ b/Sources/KClip/Views/ScrollViewSuppressionView.swift
@@ -2,11 +2,18 @@ import AppKit
 import SwiftUI
 
 struct ScrollViewSuppressionView: NSViewRepresentable {
+  final class Coordinator { weak var scrollView: NSScrollView? }
+
+  func makeCoordinator() -> Coordinator { Coordinator() }
   func makeNSView(context: Context) -> NSView { NSView(frame: .zero) }
 
   func updateNSView(_ nsView: NSView, context: Context) {
+    if isSuppressed(context.coordinator.scrollView) { return }
     DispatchQueue.main.async {
-      suppressScrollers(in: rootView(for: nsView))
+      if isSuppressed(context.coordinator.scrollView) { return }
+      guard let scrollView = firstScrollView(in: rootView(for: nsView)) else { return }
+      context.coordinator.scrollView = scrollView
+      suppress(scrollView)
     }
   }
 
@@ -16,20 +23,38 @@ struct ScrollViewSuppressionView: NSViewRepresentable {
     return current
   }
 
-  private func suppressScrollers(in view: NSView) {
-    if let scrollView = view as? NSScrollView {
-      scrollView.hasHorizontalScroller = false
-      scrollView.hasVerticalScroller = false
-      scrollView.horizontalScroller = nil
-      scrollView.verticalScroller = nil
-      scrollView.autohidesScrollers = true
-      scrollView.scrollerStyle = .overlay
-      scrollView.tile()
+  private func firstScrollView(in view: NSView) -> NSScrollView? {
+    if let scrollView = view as? NSScrollView { return scrollView }
+    for subview in view.subviews {
+      if let scrollView = firstScrollView(in: subview) { return scrollView }
     }
+    return nil
+  }
+
+  private func isSuppressed(_ scrollView: NSScrollView?) -> Bool {
+    guard let scrollView, scrollView.window != nil else { return false }
+    return scrollView.hasHorizontalScroller == false
+      && scrollView.hasVerticalScroller == false
+      && scrollView.horizontalScroller == nil
+      && scrollView.verticalScroller == nil
+  }
+
+  private func suppress(_ scrollView: NSScrollView) {
+    scrollView.hasHorizontalScroller = false
+    scrollView.hasVerticalScroller = false
+    scrollView.horizontalScroller = nil
+    scrollView.verticalScroller = nil
+    scrollView.autohidesScrollers = true
+    scrollView.scrollerStyle = .overlay
+    scrollView.tile()
+    hideScrollers(in: scrollView)
+  }
+
+  private func hideScrollers(in view: NSView) {
     if let scroller = view as? NSScroller {
       scroller.isHidden = true
       scroller.alphaValue = 0
     }
-    view.subviews.forEach(suppressScrollers)
+    view.subviews.forEach(hideScrollers)
   }
 }

--- a/Tests/KClipTests/ScrollerVisibilityRegressionTests.swift
+++ b/Tests/KClipTests/ScrollerVisibilityRegressionTests.swift
@@ -16,6 +16,15 @@ struct ScrollerVisibilityRegressionTests {
     #expect(suppressorSource.contains("autohidesScrollers = true"))
   }
 
+  @Test
+  func trayCachesSuppressedScrollViewAfterDiscovery() throws {
+    let source = try String(contentsOf: sourceURL("Sources/KClip/Views/ScrollViewSuppressionView.swift"), encoding: .utf8)
+
+    #expect(source.contains("makeCoordinator()"))
+    #expect(source.contains("context.coordinator.scrollView"))
+    #expect(source.contains("context.coordinator.scrollView = scrollView"))
+  }
+
   private func sourceURL(_ path: String) -> URL {
     URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- cache the tray's discovered `NSScrollView` instead of recursively walking and retile-hitting the entire AppKit hierarchy on every SwiftUI update
- keep the existing scroll suppression behavior intact, including hidden horizontal and vertical scrollers
- add a regression test that locks in the cached-discovery path

## Root Cause
`ScrollViewSuppressionView` was traversing the full native view tree and calling `tile()` from `updateNSView` on every tray refresh. Selection changes, search state changes, preview toggles, and other animated interactions all flowed through that path, which created avoidable AppKit work and made the tray feel sluggish.

## Validation
- `swift test`
- `swift build`
- `./script/build_and_run.sh --verify`
