### PR TITLE
[codex] Fix link processing previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
       name: "KClip",
       linkerSettings: [
         .linkedFramework("AppKit"),
+        .linkedFramework("LinkPresentation"),
         .linkedFramework("SwiftUI"),
         .linkedFramework("Quartz"),
       ]

--- a/Sources/KClip/App/AppModel.swift
+++ b/Sources/KClip/App/AppModel.swift
@@ -3,6 +3,7 @@ import Foundation
 @MainActor
 final class AppModel {
   let store: ClipboardStore
+  let linkPreviews: LinkPreviewStore
   let monitor: ClipboardMonitor
   let pasteService: PasteActionService
   let permissionService: AccessibilityPermissionService
@@ -10,6 +11,7 @@ final class AppModel {
   init() {
     let store = ClipboardStore(fileURL: AppPaths.historyFileURL)
     self.store = store
+    self.linkPreviews = LinkPreviewStore()
     self.monitor = ClipboardMonitor(store: store)
     self.pasteService = PasteActionService()
     self.permissionService = AccessibilityPermissionService()

--- a/Sources/KClip/App/TrayApplicationController.swift
+++ b/Sources/KClip/App/TrayApplicationController.swift
@@ -7,6 +7,7 @@ final class TrayApplicationController {
   private let statusItemController = StatusItemController()
   private lazy var trayPanelController = TrayPanelController(
     store: model.store,
+    linkPreviews: model.linkPreviews,
     pasteService: model.pasteService,
     permissionService: model.permissionService
   )

--- a/Sources/KClip/Models/ClipTag.swift
+++ b/Sources/KClip/Models/ClipTag.swift
@@ -31,7 +31,7 @@ enum ClipTag: String, Codable, CaseIterable, Identifiable {
     var tags: [ClipTag] = [.general]
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     let lower = trimmed.lowercased()
-    if URL(string: trimmed)?.scheme != nil { tags.append(.link) }
+    if LinkTextClassifier.url(in: trimmed) != nil { tags.append(.link) }
     if looksLikeCode(lower, text) { tags.append(.code) }
     if trimmed.range(of: "#[0-9a-fA-F]{3,8}", options: .regularExpression) != nil { tags.append(.color) }
     return unique(tags)

--- a/Sources/KClip/Models/ClipboardItem+Link.swift
+++ b/Sources/KClip/Models/ClipboardItem+Link.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+extension ClipboardItem {
+  var linkURL: URL? { LinkTextClassifier.url(in: text) }
+  var isLink: Bool { linkURL != nil }
+}

--- a/Sources/KClip/Models/LinkPreviewSnapshot.swift
+++ b/Sources/KClip/Models/LinkPreviewSnapshot.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct LinkPreviewSnapshot: Equatable, Sendable {
+  enum Phase: Equatable { case loading, ready, failed }
+
+  let url: URL
+  let title: String
+  let host: String
+  let phase: Phase
+
+  init(url: URL, title: String? = nil, phase: Phase = .ready) {
+    let cleanTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    self.url = url
+    self.host = url.host?.replacingOccurrences(of: "www.", with: "") ?? url.absoluteString
+    self.title = cleanTitle.isEmpty ? self.host : cleanTitle
+    self.phase = phase
+  }
+
+  static func loading(url: URL) -> LinkPreviewSnapshot {
+    LinkPreviewSnapshot(url: url, phase: .loading)
+  }
+
+  static func failed(url: URL) -> LinkPreviewSnapshot {
+    LinkPreviewSnapshot(url: url, phase: .failed)
+  }
+
+  var subtitle: String {
+    switch phase {
+    case .loading: "Fetching web page preview"
+    case .failed: "Preview unavailable"
+    case .ready: title == host ? "Web page preview" : host
+    }
+  }
+
+  var badge: String {
+    switch phase {
+    case .loading: "Loading"
+    case .failed: "Unavailable"
+    case .ready: "Web Page"
+    }
+  }
+}

--- a/Sources/KClip/Services/LinkPreviewLoading.swift
+++ b/Sources/KClip/Services/LinkPreviewLoading.swift
@@ -1,0 +1,26 @@
+import Foundation
+@preconcurrency import LinkPresentation
+
+protocol LinkPreviewLoading {
+  func loadPreview(for url: URL, completion: @escaping @Sendable (Result<LinkPreviewSnapshot, Error>) -> Void)
+}
+
+final class LiveLinkPreviewLoader: LinkPreviewLoading {
+  func loadPreview(for url: URL, completion: @escaping @Sendable (Result<LinkPreviewSnapshot, Error>) -> Void) {
+    let provider = LPMetadataProvider()
+    provider.timeout = 3
+    provider.startFetchingMetadata(for: url) { metadata, error in
+      _ = provider
+      if let metadata {
+        let resolvedURL = metadata.originalURL ?? metadata.url ?? url
+        completion(.success(LinkPreviewSnapshot(url: resolvedURL, title: metadata.title)))
+      } else {
+        completion(.failure(error ?? LinkPreviewLoaderError.unavailable))
+      }
+    }
+  }
+}
+
+enum LinkPreviewLoaderError: Error {
+  case unavailable
+}

--- a/Sources/KClip/Services/TrayPanelController.swift
+++ b/Sources/KClip/Services/TrayPanelController.swift
@@ -4,6 +4,7 @@ import SwiftUI
 @MainActor
 final class TrayPanelController {
   let store: ClipboardStore
+  let linkPreviews: LinkPreviewStore
   let pasteService: PasteActionService
   let permissionService: AccessibilityPermissionService
   let interaction = TrayInteractionModel()
@@ -21,10 +22,12 @@ final class TrayPanelController {
   var lastToggleAt: Date?
   init(
     store: ClipboardStore,
+    linkPreviews: LinkPreviewStore,
     pasteService: PasteActionService,
     permissionService: AccessibilityPermissionService
   ) {
     self.store = store
+    self.linkPreviews = linkPreviews
     self.pasteService = pasteService
     self.permissionService = permissionService
     configurePanel()
@@ -79,6 +82,7 @@ final class TrayPanelController {
     let view = TrayPanelRootView(
       panelWidth: size.width,
       store: store,
+      linkPreviews: linkPreviews,
       interaction: interaction,
       isPermissionGranted: permissionService.hasAccess(),
       onClose: { [weak self] in self?.closeAndReturnToPrevious() },

--- a/Sources/KClip/Stores/LinkPreviewStore.swift
+++ b/Sources/KClip/Stores/LinkPreviewStore.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class LinkPreviewStore {
+  private(set) var models: [String: LinkPreviewSnapshot] = [:]
+  private let loader: LinkPreviewLoading
+  private var inFlight = Set<String>()
+
+  init(loader: LinkPreviewLoading = LiveLinkPreviewLoader()) {
+    self.loader = loader
+  }
+
+  func model(for item: ClipboardItem) -> LinkPreviewSnapshot? {
+    guard let url = item.linkURL else { return nil }
+    return models[url.absoluteString] ?? .loading(url: url)
+  }
+
+  func warm(_ items: [ClipboardItem]) {
+    items.compactMap(\.linkURL).forEach(request)
+  }
+
+  private func request(_ url: URL) {
+    let key = url.absoluteString
+    guard inFlight.contains(key) == false, models[key]?.phase != .ready, models[key]?.phase != .failed else { return }
+    inFlight.insert(key)
+    models[key] = models[key] ?? .loading(url: url)
+    loader.loadPreview(for: url) { [weak self] result in
+      let preview = try? result.get()
+      if Thread.isMainThread {
+        MainActor.assumeIsolated { self?.finish(preview, key: key, url: url) }
+      } else {
+        Task { @MainActor [weak self] in
+          self?.finish(preview, key: key, url: url)
+        }
+      }
+    }
+  }
+
+  private func finish(_ preview: LinkPreviewSnapshot?, key: String, url: URL) {
+    inFlight.remove(key)
+    models[key] = preview ?? .failed(url: url)
+  }
+}

--- a/Sources/KClip/Support/LinkTextClassifier.swift
+++ b/Sources/KClip/Support/LinkTextClassifier.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+enum LinkTextClassifier {
+  static func url(in text: String) -> URL? {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.isEmpty == false else { return nil }
+    let types = NSTextCheckingResult.CheckingType.link.rawValue
+    guard let detector = try? NSDataDetector(types: types) else { return nil }
+    let range = NSRange(trimmed.startIndex..<trimmed.endIndex, in: trimmed)
+    let matches = detector.matches(in: trimmed, options: [], range: range)
+    guard matches.count == 1, matches[0].range == range, let url = matches[0].url else { return nil }
+    guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme), url.host?.isEmpty == false else {
+      return nil
+    }
+    return url
+  }
+}

--- a/Sources/KClip/Views/ClipEditorOverlayView.swift
+++ b/Sources/KClip/Views/ClipEditorOverlayView.swift
@@ -1,13 +1,14 @@
 import SwiftUI
 
 struct ClipEditorOverlayView: View {
+  let item: ClipboardItem
   @Binding var text: String
   let onCancel: () -> Void
   let onSave: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("Edit Clip")
+      Text(item.isLink ? "Edit Link" : "Edit Clip")
         .font(.system(size: 15, weight: .bold, design: .rounded))
       TextEditor(text: $text)
         .scrollContentBackground(.hidden)

--- a/Sources/KClip/Views/ClipPreviewOverlayView.swift
+++ b/Sources/KClip/Views/ClipPreviewOverlayView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ClipPreviewOverlayView: View {
   let item: ClipboardItem
+  let linkPreviews: LinkPreviewStore
   let onClose: () -> Void
 
   var body: some View {
@@ -15,6 +16,21 @@ struct ClipPreviewOverlayView: View {
         Button(action: onClose) { Image(systemName: "xmark.circle.fill").font(.system(size: 14, weight: .semibold)) }
           .buttonStyle(.plain)
       }
+      previewBody
+    }
+    .padding(20)
+    .frame(width: 470, height: 210, alignment: .topLeading)
+    .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(.regularMaterial))
+    .overlay(RoundedRectangle(cornerRadius: 24, style: .continuous).stroke(Color.white.opacity(0.10), lineWidth: 1))
+    .onAppear { linkPreviews.warm([item]) }
+  }
+
+  @ViewBuilder
+  private var previewBody: some View {
+    if let preview = linkPreviews.model(for: item) {
+      if preview.phase == .ready { LinkPreviewRepresentable(preview: preview) }
+      else { LinkPreviewSummaryView(preview: preview, compact: false) }
+    } else {
       ScrollView {
         Text(item.text)
           .font(.system(size: 14, weight: .semibold, design: .rounded))
@@ -22,9 +38,5 @@ struct ClipPreviewOverlayView: View {
           .frame(maxWidth: .infinity, alignment: .topLeading)
       }
     }
-    .padding(20)
-    .frame(width: 470, height: 210, alignment: .topLeading)
-    .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(.regularMaterial))
-    .overlay(RoundedRectangle(cornerRadius: 24, style: .continuous).stroke(Color.white.opacity(0.10), lineWidth: 1))
   }
 }

--- a/Sources/KClip/Views/ClipTrayRailView.swift
+++ b/Sources/KClip/Views/ClipTrayRailView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ClipTrayRailView: View {
   let items: [ClipboardItem]
+  let linkPreviews: LinkPreviewStore
   @ObservedObject var interaction: TrayInteractionModel
   let isStaged: Bool
   let selectIndex: (Int) -> Void
@@ -40,7 +41,9 @@ struct ClipTrayRailView: View {
   }
 
   private func card(_ item: ClipboardItem, at index: Int) -> some View {
-    Button { selectIndex(index) } label: { TrayCardView(item: item, isSelected: index == interaction.selection.index) }
+    Button { selectIndex(index) } label: {
+      TrayCardView(item: item, linkPreviews: linkPreviews, isSelected: index == interaction.selection.index)
+    }
       .buttonStyle(.plain)
       .id(item.id)
       .opacity(isStaged ? 1 : 0)

--- a/Sources/KClip/Views/ClipTrayView.swift
+++ b/Sources/KClip/Views/ClipTrayView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ClipTrayView: View {
   let items: [ClipboardItem]
   let tags: [ClipTag]
+  let linkPreviews: LinkPreviewStore
   @ObservedObject var interaction: TrayInteractionModel
   let isStaged: Bool
   let selectIndex: (Int) -> Void
@@ -34,6 +35,7 @@ struct ClipTrayView: View {
   private var cardsRailView: some View {
     ClipTrayRailView(
       items: items,
+      linkPreviews: linkPreviews,
       interaction: interaction,
       isStaged: isStaged,
       selectIndex: selectIndex,

--- a/Sources/KClip/Views/LinkPreviewRepresentable.swift
+++ b/Sources/KClip/Views/LinkPreviewRepresentable.swift
@@ -1,0 +1,16 @@
+import LinkPresentation
+import SwiftUI
+
+struct LinkPreviewRepresentable: NSViewRepresentable {
+  let preview: LinkPreviewSnapshot
+
+  func makeNSView(context: Context) -> LPLinkView {
+    let metadata = LPLinkMetadata()
+    metadata.originalURL = preview.url
+    metadata.url = preview.url
+    metadata.title = preview.title
+    return LPLinkView(metadata: metadata)
+  }
+
+  func updateNSView(_ nsView: LPLinkView, context: Context) {}
+}

--- a/Sources/KClip/Views/LinkPreviewSummaryView.swift
+++ b/Sources/KClip/Views/LinkPreviewSummaryView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct LinkPreviewSummaryView: View {
+  let preview: LinkPreviewSnapshot
+  let compact: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: compact ? 8 : 12) {
+      HStack(spacing: 8) {
+        Image(systemName: "globe")
+          .font(.system(size: compact ? 12 : 13, weight: .bold))
+        Text(preview.badge)
+          .font(.system(size: compact ? 10 : 11, weight: .bold, design: .rounded))
+        Spacer(minLength: 0)
+        if preview.phase == .loading { ProgressView().controlSize(.small) }
+      }
+      Text(preview.title)
+        .font(.system(size: compact ? 13 : 15, weight: .bold, design: .rounded))
+        .lineLimit(compact ? 3 : 2)
+      Text(preview.subtitle)
+        .font(.system(size: compact ? 10 : 12, weight: .semibold, design: .rounded))
+        .foregroundStyle(Color.white.opacity(0.60))
+        .lineLimit(1)
+      Spacer(minLength: 0)
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+  }
+}

--- a/Sources/KClip/Views/TrayCardView.swift
+++ b/Sources/KClip/Views/TrayCardView.swift
@@ -2,17 +2,13 @@ import SwiftUI
 
 struct TrayCardView: View {
   let item: ClipboardItem
+  let linkPreviews: LinkPreviewStore
   let isSelected: Bool
 
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
       headerBlock
-      Text(item.text)
-        .font(.system(size: 14, weight: .semibold, design: .rounded))
-        .lineSpacing(1.5)
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82, alignment: .topLeading)
-        .mask { OverflowFadeView(isEnabled: item.text.count > 110) }
+      contentBlock
       Spacer(minLength: 0)
     }
     .padding(18)
@@ -28,6 +24,21 @@ struct TrayCardView: View {
     VStack(alignment: .leading, spacing: 9) {
       headerRow
       sourceRow(sourceLine)
+    }
+  }
+
+  @ViewBuilder
+  private var contentBlock: some View {
+    if let preview = linkPreviews.model(for: item) {
+      LinkPreviewSummaryView(preview: preview, compact: true)
+        .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82, alignment: .topLeading)
+    } else {
+      Text(item.text)
+        .font(.system(size: 14, weight: .semibold, design: .rounded))
+        .lineSpacing(1.5)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, minHeight: 82, maxHeight: 82, alignment: .topLeading)
+        .mask { OverflowFadeView(isEnabled: item.text.count > 110) }
     }
   }
 

--- a/Sources/KClip/Views/TrayEditorStageView.swift
+++ b/Sources/KClip/Views/TrayEditorStageView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct TrayEditorStageView: View {
+  let item: ClipboardItem
   @Binding var text: String
   let onCancel: () -> Void
   let onSave: () -> Void
@@ -10,7 +11,7 @@ struct TrayEditorStageView: View {
       Color.black.opacity(0.18)
         .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
         .transition(.opacity)
-      ClipEditorOverlayView(text: $text, onCancel: onCancel, onSave: onSave)
+      ClipEditorOverlayView(item: item, text: $text, onCancel: onCancel, onSave: onSave)
         .padding(.top, 10)
         .transition(
           .asymmetric(

--- a/Sources/KClip/Views/TrayPanelRootView+Actions.swift
+++ b/Sources/KClip/Views/TrayPanelRootView+Actions.swift
@@ -3,6 +3,7 @@ import SwiftUI
 extension TrayPanelRootView {
   func stageTray() {
     syncSelection()
+    warmLinkPreviews()
     DispatchQueue.main.async {
       withAnimation(.spring(response: 0.24, dampingFraction: 0.86)) { isStaged = true }
     }
@@ -10,11 +11,13 @@ extension TrayPanelRootView {
 
   func syncFromStore() {
     syncSelection()
+    warmLinkPreviews()
     interaction.syncPreview(with: store.items)
   }
 
   func syncSelection() {
     interaction.normalize(itemCount: visibleItems.count)
+    warmLinkPreviews()
   }
 
   func activate(_ index: Int) {
@@ -74,5 +77,9 @@ extension TrayPanelRootView {
       editingItem = nil
     }
     onRefocus()
+  }
+
+  func warmLinkPreviews() {
+    linkPreviews.warm(visibleItems)
   }
 }

--- a/Sources/KClip/Views/TrayPanelRootView.swift
+++ b/Sources/KClip/Views/TrayPanelRootView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct TrayPanelRootView: View {
   let panelWidth: CGFloat
   let store: ClipboardStore
+  let linkPreviews: LinkPreviewStore
   @ObservedObject var interaction: TrayInteractionModel
   let isPermissionGranted: Bool
   let onClose: () -> Void
@@ -20,6 +21,7 @@ struct TrayPanelRootView: View {
       ClipTrayView(
         items: visibleItems,
         tags: displayedTags,
+        linkPreviews: linkPreviews,
         interaction: interaction,
         isStaged: isStaged,
         selectIndex: activate,
@@ -38,8 +40,12 @@ struct TrayPanelRootView: View {
       if isPermissionGranted == false {
         TrayPermissionBlockView(onOpenPermissions: onOpenPermissions, onRestart: onRestartPermissions)
       }
-      if let item = interaction.previewItem { TrayPreviewStageView(item: item, onClose: interaction.dismissPreview) }
-      if editingItem != nil { TrayEditorStageView(text: $draftText, onCancel: endEditing, onSave: saveEdit) }
+      if let item = interaction.previewItem {
+        TrayPreviewStageView(item: item, linkPreviews: linkPreviews, onClose: interaction.dismissPreview)
+      }
+      if let editingItem {
+        TrayEditorStageView(item: editingItem, text: $draftText, onCancel: endEditing, onSave: saveEdit)
+      }
     }
     .padding(.horizontal, 18)
     .padding(.vertical, 12)

--- a/Sources/KClip/Views/TrayPreviewStageView.swift
+++ b/Sources/KClip/Views/TrayPreviewStageView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TrayPreviewStageView: View {
   let item: ClipboardItem
+  let linkPreviews: LinkPreviewStore
   let onClose: () -> Void
 
   var body: some View {
@@ -11,7 +12,7 @@ struct TrayPreviewStageView: View {
         .contentShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
         .onTapGesture(perform: onClose)
         .transition(.opacity)
-      ClipPreviewOverlayView(item: item, onClose: onClose)
+      ClipPreviewOverlayView(item: item, linkPreviews: linkPreviews, onClose: onClose)
         .padding(.top, 6)
         .transition(.asymmetric(insertion: .offset(y: 18).combined(with: .opacity), removal: .opacity))
     }

--- a/Tests/KClipTests/LinkPreviewStoreTests.swift
+++ b/Tests/KClipTests/LinkPreviewStoreTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import KClip
+
+@MainActor
+@Suite("LinkPreviewStoreTests")
+struct LinkPreviewStoreTests {
+  @Test
+  func warmsLinkItemsAndCachesResolvedPreview() {
+    let loader = LoaderStub()
+    let store = LinkPreviewStore(loader: loader)
+    let item = ClipboardItem(text: "https://example.com/articles/ship-fast")
+    let url = try! #require(item.linkURL)
+
+    store.warm([item])
+
+    #expect(loader.urls == [url])
+    #expect(store.model(for: item)?.phase == .loading)
+
+    loader.succeed(url: url, title: "Ship Fast")
+
+    #expect(store.model(for: item)?.phase == .ready)
+    #expect(store.model(for: item)?.title == "Ship Fast")
+    store.warm([item])
+    #expect(loader.urls == [url])
+  }
+
+  @Test
+  func ignoresPlainTextItems() {
+    let loader = LoaderStub()
+    let store = LinkPreviewStore(loader: loader)
+
+    store.warm([ClipboardItem(text: "plain text")])
+
+    #expect(loader.urls.isEmpty)
+  }
+
+  private final class LoaderStub: LinkPreviewLoading {
+    var urls: [URL] = []
+    var completions: [String: (Result<LinkPreviewSnapshot, Error>) -> Void] = [:]
+
+    func loadPreview(for url: URL, completion: @escaping (Result<LinkPreviewSnapshot, Error>) -> Void) {
+      urls.append(url)
+      completions[url.absoluteString] = completion
+    }
+
+    func succeed(url: URL, title: String) {
+      completions[url.absoluteString]?(.success(LinkPreviewSnapshot(url: url, title: title)))
+    }
+  }
+}

--- a/Tests/KClipTests/LinkTextClassifierTests.swift
+++ b/Tests/KClipTests/LinkTextClassifierTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import KClip
+
+@Suite("LinkTextClassifierTests")
+struct LinkTextClassifierTests {
+  @Test
+  func extractsSingleWebURL() {
+    #expect(LinkTextClassifier.url(in: " https://example.com/docs ")?.absoluteString == "https://example.com/docs")
+    #expect(ClipboardItem(text: "https://example.com/docs").linkURL?.host == "example.com")
+  }
+
+  @Test
+  func rejectsMixedTextAndLink() {
+    let text = "Read this first https://example.com/docs"
+
+    #expect(LinkTextClassifier.url(in: text) == nil)
+    #expect(ClipTag.inferredTags(for: text).contains(.link) == false)
+  }
+
+  @Test
+  func rejectsNonWebSchemes() {
+    #expect(LinkTextClassifier.url(in: "mailto:test@example.com") == nil)
+  }
+}


### PR DESCRIPTION
## Summary
- detect only standalone `http/https` clipboard links and keep mixed text clips out of the Link tag
- resolve webpage previews asynchronously so tray cards and preview overlays show page metadata without blocking capture
- keep link editing focused on the stored URL while preserving the repo's sub-120-line file rule

## Root Cause
Link handling only looked at raw clip text. Any pure URL stayed a plain string clip, and the tray/preview/editor UI had no separate link-preview pipeline.

## Validation
- `swift test`
- `./script/build_and_run.sh --verify`
