### PR TITLE
[codex] Improve link preview artwork fallback

### DIFF
--- a/Sources/KClip/Models/LinkPreviewSnapshot.swift
+++ b/Sources/KClip/Models/LinkPreviewSnapshot.swift
@@ -9,6 +9,7 @@ struct LinkPreviewSnapshot {
   let host: String
   let phase: Phase
   let image: NSImage?
+  var displayImage: NSImage? { LinkPreviewImageAnalyzer.displayImage(from: image) }
 
   init(url: URL, title: String? = nil, phase: Phase = .ready, image: NSImage? = nil) {
     let cleanTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/Sources/KClip/Support/LinkPreviewImageAnalyzer.swift
+++ b/Sources/KClip/Support/LinkPreviewImageAnalyzer.swift
@@ -1,0 +1,57 @@
+import AppKit
+
+enum LinkPreviewImageAnalyzer {
+  static func displayImage(from image: NSImage?) -> NSImage? {
+    guard let image, shouldShow(image) else { return nil }
+    return image
+  }
+
+  private static func shouldShow(_ image: NSImage) -> Bool {
+    guard let rep = bitmapRep(for: image) else { return true }
+    let points = sampledLuminance(from: rep)
+    guard points.isEmpty == false else { return true }
+    let mean = points.reduce(0, +) / CGFloat(points.count)
+    let variance = points.reduce(0) { $0 + pow($1 - mean, 2) } / CGFloat(points.count)
+    if variance < 0.004 { return false }
+    return !(mean > 0.86 && variance < 0.012)
+  }
+
+  private static func sampledLuminance(from rep: NSBitmapImageRep) -> [CGFloat] {
+    let stepX = max(1, rep.pixelsWide / 18)
+    let stepY = max(1, rep.pixelsHigh / 18)
+    var values: [CGFloat] = []
+    for y in stride(from: 0, to: rep.pixelsHigh, by: stepY) {
+      for x in stride(from: 0, to: rep.pixelsWide, by: stepX) {
+        guard let color = rep.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+        values.append((0.2126 * color.redComponent) + (0.7152 * color.greenComponent) + (0.0722 * color.blueComponent))
+      }
+    }
+    return values
+  }
+
+  private static func bitmapRep(for image: NSImage) -> NSBitmapImageRep? {
+    if let rep = image.representations.compactMap({ $0 as? NSBitmapImageRep }).first { return rep }
+    let width = max(1, Int(image.size.width))
+    let height = max(1, Int(image.size.height))
+    guard
+      let rep = NSBitmapImageRep(
+        bitmapDataPlanes: nil,
+        pixelsWide: width,
+        pixelsHigh: height,
+        bitsPerSample: 8,
+        samplesPerPixel: 4,
+        hasAlpha: true,
+        isPlanar: false,
+        colorSpaceName: .deviceRGB,
+        bytesPerRow: 0,
+        bitsPerPixel: 0
+      )
+    else { return nil }
+    rep.size = image.size
+    NSGraphicsContext.saveGraphicsState()
+    NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+    image.draw(in: NSRect(origin: .zero, size: image.size))
+    NSGraphicsContext.restoreGraphicsState()
+    return rep
+  }
+}

--- a/Sources/KClip/Views/LinkPreviewSummaryView.swift
+++ b/Sources/KClip/Views/LinkPreviewSummaryView.swift
@@ -18,8 +18,9 @@ struct LinkPreviewSummaryView: View {
   private var mediaBlock: some View {
     ZStack(alignment: .topLeading) {
       backgroundBlock
-      LinearGradient(colors: [.clear, .black.opacity(compact ? 0.12 : 0.22)], startPoint: .top, endPoint: .bottom)
-      badgeRow.padding(compact ? 10 : 12)
+      LinearGradient(colors: [.black.opacity(0.02), .black.opacity(compact ? 0.18 : 0.30)], startPoint: .top, endPoint: .bottom)
+      chromeBar
+      badgeRow.padding(compact ? 11 : 14)
     }
     .clipShape(RoundedRectangle(cornerRadius: compact ? 18 : 20, style: .continuous))
     .overlay(RoundedRectangle(cornerRadius: compact ? 18 : 20, style: .continuous).stroke(Color.white.opacity(0.08), lineWidth: 1))
@@ -49,21 +50,38 @@ struct LinkPreviewSummaryView: View {
     .foregroundStyle(.white.opacity(0.92))
   }
 
+  private var chromeBar: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 5) {
+        ForEach([0.30, 0.24, 0.18], id: \.self) { opacity in
+          Circle().fill(Color.white.opacity(opacity)).frame(width: compact ? 5 : 6, height: compact ? 5 : 6)
+        }
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, compact ? 10 : 12)
+      .padding(.top, compact ? 8 : 10)
+      Spacer(minLength: 0)
+    }
+  }
+
   @ViewBuilder
   private var backgroundBlock: some View {
-    if let image = preview.image {
+    if let image = preview.displayImage {
       Image(nsImage: image)
         .resizable()
         .scaledToFill()
-        .saturation(0.88)
-        .brightness(-0.04)
+        .saturation(0.82)
+        .brightness(-0.08)
     } else {
-      LinearGradient(colors: [Color.white.opacity(0.12), Color.white.opacity(0.04)], startPoint: .topLeading, endPoint: .bottomTrailing)
-      Text(preview.host.uppercased())
-        .font(.system(size: compact ? 15 : 20, weight: .black, design: .rounded))
-        .foregroundStyle(Color.white.opacity(0.14))
-        .padding(compact ? 10 : 14)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+      LinearGradient(colors: [Color.white.opacity(0.12), Color.white.opacity(0.03)], startPoint: .topLeading, endPoint: .bottomTrailing)
+      VStack(alignment: .leading, spacing: compact ? 6 : 8) {
+        Text(preview.host.uppercased())
+          .font(.system(size: compact ? 13 : 18, weight: .black, design: .rounded))
+          .foregroundStyle(Color.white.opacity(0.18))
+        Capsule().fill(Color.white.opacity(0.08)).frame(width: compact ? 44 : 60, height: compact ? 6 : 8)
+      }
+      .padding(compact ? 12 : 16)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }
   }
 }

--- a/Tests/KClipTests/LinkPreviewSnapshotTests.swift
+++ b/Tests/KClipTests/LinkPreviewSnapshotTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import Foundation
+import Testing
+@testable import KClip
+
+@Suite("LinkPreviewSnapshotTests")
+struct LinkPreviewSnapshotTests {
+  @Test
+  func blankArtworkFallsBackToDesignedCard() {
+    let preview = LinkPreviewSnapshot(url: URL(string: "https://example.com")!, title: "Example", image: solidImage(.white))
+
+    #expect(preview.displayImage == nil)
+  }
+
+  @Test
+  func detailedArtworkRemainsAvailable() {
+    let preview = LinkPreviewSnapshot(url: URL(string: "https://example.com")!, title: "Example", image: stripedImage())
+
+    #expect(preview.displayImage != nil)
+  }
+
+  private func solidImage(_ color: NSColor) -> NSImage {
+    let image = NSImage(size: NSSize(width: 64, height: 64))
+    image.lockFocus()
+    color.setFill()
+    NSBezierPath(rect: NSRect(origin: .zero, size: image.size)).fill()
+    image.unlockFocus()
+    return image
+  }
+
+  private func stripedImage() -> NSImage {
+    let image = solidImage(.white)
+    image.lockFocus()
+    NSColor.black.setFill()
+    for offset in stride(from: 0, to: 64, by: 8) {
+      NSBezierPath(rect: NSRect(x: offset, y: 0, width: 4, height: 64)).fill()
+    }
+    image.unlockFocus()
+    return image
+  }
+}

--- a/Tests/KClipTests/TrayCardRegressionTests.swift
+++ b/Tests/KClipTests/TrayCardRegressionTests.swift
@@ -42,6 +42,8 @@ struct TrayCardRegressionTests {
     #expect(source.contains("detailsBlock"))
     #expect(source.contains(".frame(height: mediaHeight)"))
     #expect(source.contains(".lineLimit(compact ? 2 : 3)"))
+    #expect(source.contains("preview.displayImage"))
+    #expect(source.contains("chromeBar"))
   }
 
   private var rootURL: URL {


### PR DESCRIPTION
## Summary
- detect low-information webpage snapshots and fall back to a designed site card instead of rendering empty white slabs
- give link preview cards a cleaner browser-style chrome treatment so useful captures feel deliberate
- add regressions for artwork quality gating and the new compact preview layout behavior

## Root Cause
The previous preview design assumed every captured webpage snapshot was visually useful. In practice, many pages produced mostly blank white captures, so the UI kept presenting empty slabs as if they were valid preview artwork.

## Validation
- `swift test`
- `./script/build_and_run.sh --verify`
- Swift line-count audit (`0` files over `120` lines)
