### PR TITLE
[codex] Fix link preview footer layout

### DIFF
--- a/Sources/KClip/Models/LinkPreviewSnapshot.swift
+++ b/Sources/KClip/Models/LinkPreviewSnapshot.swift
@@ -9,7 +9,7 @@ struct LinkPreviewSnapshot {
   let host: String
   let phase: Phase
   let image: NSImage?
-  var displayImage: NSImage? { LinkPreviewImageAnalyzer.displayImage(from: image) }
+  let displayImage: NSImage?
 
   init(url: URL, title: String? = nil, phase: Phase = .ready, image: NSImage? = nil) {
     let cleanTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -18,6 +18,7 @@ struct LinkPreviewSnapshot {
     self.title = cleanTitle.isEmpty ? self.host : cleanTitle
     self.phase = phase
     self.image = image
+    self.displayImage = LinkPreviewImageAnalyzer.displayImage(from: image)
   }
 
   static func loading(url: URL) -> LinkPreviewSnapshot {

--- a/Sources/KClip/Support/LinkPreviewImageAnalyzer.swift
+++ b/Sources/KClip/Support/LinkPreviewImageAnalyzer.swift
@@ -2,31 +2,57 @@ import AppKit
 
 enum LinkPreviewImageAnalyzer {
   static func displayImage(from image: NSImage?) -> NSImage? {
-    guard let image, shouldShow(image) else { return nil }
-    return image
+    guard let image else { return nil }
+    return shouldShow(image) ? image : nil
   }
 
   private static func shouldShow(_ image: NSImage) -> Bool {
     guard let rep = bitmapRep(for: image) else { return true }
-    let points = sampledLuminance(from: rep)
+    let grid = sampledLuminanceGrid(from: rep)
+    let points = grid.flatMap(\.self)
     guard points.isEmpty == false else { return true }
     let mean = points.reduce(0, +) / CGFloat(points.count)
     let variance = points.reduce(0) { $0 + pow($1 - mean, 2) } / CGFloat(points.count)
-    if variance < 0.004 { return false }
-    return !(mean > 0.86 && variance < 0.012)
+    let range = (points.max() ?? mean) - (points.min() ?? mean)
+    let edges = edgeFraction(in: grid)
+    if variance < 0.001 && range < 0.05 { return false }
+    if mean > 0.95 && range < 0.12 && edges < 0.04 { return false }
+    return edges > 0.03 || range > 0.14 || variance > 0.003
   }
 
-  private static func sampledLuminance(from rep: NSBitmapImageRep) -> [CGFloat] {
-    let stepX = max(1, rep.pixelsWide / 18)
-    let stepY = max(1, rep.pixelsHigh / 18)
-    var values: [CGFloat] = []
+  private static func sampledLuminanceGrid(from rep: NSBitmapImageRep) -> [[CGFloat]] {
+    let stepX = max(1, rep.pixelsWide / 28)
+    let stepY = max(1, rep.pixelsHigh / 20)
+    var rows: [[CGFloat]] = []
     for y in stride(from: 0, to: rep.pixelsHigh, by: stepY) {
+      var row: [CGFloat] = []
       for x in stride(from: 0, to: rep.pixelsWide, by: stepX) {
         guard let color = rep.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
-        values.append((0.2126 * color.redComponent) + (0.7152 * color.greenComponent) + (0.0722 * color.blueComponent))
+        row.append((0.2126 * color.redComponent) + (0.7152 * color.greenComponent) + (0.0722 * color.blueComponent))
+      }
+      if row.isEmpty == false { rows.append(row) }
+    }
+    return rows
+  }
+
+  private static func edgeFraction(in grid: [[CGFloat]]) -> CGFloat {
+    var edges = 0
+    var comparisons = 0
+    for y in grid.indices {
+      for x in grid[y].indices {
+        let value = grid[y][x]
+        if x + 1 < grid[y].count {
+          comparisons += 1
+          if abs(value - grid[y][x + 1]) > 0.12 { edges += 1 }
+        }
+        if y + 1 < grid.count, x < grid[y + 1].count {
+          comparisons += 1
+          if abs(value - grid[y + 1][x]) > 0.12 { edges += 1 }
+        }
       }
     }
-    return values
+    guard comparisons > 0 else { return 0 }
+    return CGFloat(edges) / CGFloat(comparisons)
   }
 
   private static func bitmapRep(for image: NSImage) -> NSBitmapImageRep? {

--- a/Sources/KClip/Views/LinkPreviewSummaryView.swift
+++ b/Sources/KClip/Views/LinkPreviewSummaryView.swift
@@ -5,28 +5,24 @@ struct LinkPreviewSummaryView: View {
   let compact: Bool
 
   var body: some View {
-    VStack(alignment: .leading, spacing: compact ? 8 : 12) {
-      mediaBlock
-        .frame(height: mediaHeight)
-      detailsBlock
-    }
+    mediaBlock
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
   }
-
-  private var mediaHeight: CGFloat { compact ? 52 : 136 }
 
   private var mediaBlock: some View {
     ZStack(alignment: .topLeading) {
       backgroundBlock
-      LinearGradient(colors: [.black.opacity(0.02), .black.opacity(compact ? 0.18 : 0.30)], startPoint: .top, endPoint: .bottom)
+      topShade
+      bottomShade
       chromeBar
-      badgeRow.padding(compact ? 11 : 14)
+      statusBadge
+      footerBlock
     }
     .clipShape(RoundedRectangle(cornerRadius: compact ? 18 : 20, style: .continuous))
     .overlay(RoundedRectangle(cornerRadius: compact ? 18 : 20, style: .continuous).stroke(Color.white.opacity(0.08), lineWidth: 1))
   }
 
-  private var detailsBlock: some View {
+  private var footerBlock: some View {
     VStack(alignment: .leading, spacing: compact ? 4 : 6) {
       Text(preview.title)
         .font(.system(size: compact ? 12 : 16, weight: .bold, design: .rounded))
@@ -37,6 +33,10 @@ struct LinkPreviewSummaryView: View {
         .foregroundStyle(Color.white.opacity(0.60))
         .lineLimit(1)
     }
+    .padding(.horizontal, compact ? 12 : 16)
+    .padding(.top, compact ? 18 : 28)
+    .padding(.bottom, compact ? 12 : 16)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
   }
 
   private var badgeRow: some View {
@@ -48,6 +48,25 @@ struct LinkPreviewSummaryView: View {
     }
     .font(.system(size: compact ? 10 : 11, weight: .bold, design: .rounded))
     .foregroundStyle(.white.opacity(0.92))
+  }
+
+  @ViewBuilder
+  private var statusBadge: some View {
+    if preview.phase != .ready {
+      badgeRow.padding(.horizontal, compact ? 11 : 14).padding(.top, compact ? 11 : 14)
+    }
+  }
+
+  private var topShade: some View {
+    LinearGradient(colors: [.black.opacity(0.10), .clear], startPoint: .top, endPoint: .center)
+  }
+
+  private var bottomShade: some View {
+    LinearGradient(
+      stops: [.init(color: .clear, location: 0.0), .init(color: .black.opacity(compact ? 0.16 : 0.10), location: 0.48), .init(color: .black.opacity(compact ? 0.62 : 0.52), location: 1.0)],
+      startPoint: .top,
+      endPoint: .bottom
+    )
   }
 
   private var chromeBar: some View {
@@ -70,15 +89,18 @@ struct LinkPreviewSummaryView: View {
       Image(nsImage: image)
         .resizable()
         .scaledToFill()
-        .saturation(0.82)
-        .brightness(-0.08)
+        .saturation(0.94)
+        .contrast(1.02)
     } else {
       LinearGradient(colors: [Color.white.opacity(0.12), Color.white.opacity(0.03)], startPoint: .topLeading, endPoint: .bottomTrailing)
       VStack(alignment: .leading, spacing: compact ? 6 : 8) {
+        Capsule().fill(Color.white.opacity(0.10)).frame(width: compact ? 52 : 72, height: compact ? 6 : 8)
+        RoundedRectangle(cornerRadius: compact ? 10 : 12, style: .continuous)
+          .fill(Color.white.opacity(0.05))
+          .frame(height: compact ? 20 : 32)
         Text(preview.host.uppercased())
-          .font(.system(size: compact ? 13 : 18, weight: .black, design: .rounded))
+          .font(.system(size: compact ? 12 : 17, weight: .black, design: .rounded))
           .foregroundStyle(Color.white.opacity(0.18))
-        Capsule().fill(Color.white.opacity(0.08)).frame(width: compact ? 44 : 60, height: compact ? 6 : 8)
       }
       .padding(compact ? 12 : 16)
       .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)

--- a/Tests/KClipTests/LinkPreviewSnapshotTests.swift
+++ b/Tests/KClipTests/LinkPreviewSnapshotTests.swift
@@ -19,6 +19,13 @@ struct LinkPreviewSnapshotTests {
     #expect(preview.displayImage != nil)
   }
 
+  @Test
+  func lowContrastArtworkRemainsAvailable() {
+    let preview = LinkPreviewSnapshot(url: URL(string: "https://example.com")!, title: "Example", image: subtleLayoutImage())
+
+    #expect(preview.displayImage != nil)
+  }
+
   private func solidImage(_ color: NSColor) -> NSImage {
     let image = NSImage(size: NSSize(width: 64, height: 64))
     image.lockFocus()
@@ -35,6 +42,19 @@ struct LinkPreviewSnapshotTests {
     for offset in stride(from: 0, to: 64, by: 8) {
       NSBezierPath(rect: NSRect(x: offset, y: 0, width: 4, height: 64)).fill()
     }
+    image.unlockFocus()
+    return image
+  }
+
+  private func subtleLayoutImage() -> NSImage {
+    let image = solidImage(.white)
+    image.lockFocus()
+    NSColor(calibratedWhite: 0.86, alpha: 1).setFill()
+    NSBezierPath(rect: NSRect(x: 6, y: 44, width: 52, height: 10)).fill()
+    NSBezierPath(rect: NSRect(x: 6, y: 28, width: 40, height: 6)).fill()
+    NSBezierPath(rect: NSRect(x: 6, y: 16, width: 32, height: 6)).fill()
+    NSColor(calibratedWhite: 0.72, alpha: 1).setFill()
+    NSBezierPath(rect: NSRect(x: 46, y: 16, width: 12, height: 38)).fill()
     image.unlockFocus()
     return image
   }

--- a/Tests/KClipTests/TrayCardRegressionTests.swift
+++ b/Tests/KClipTests/TrayCardRegressionTests.swift
@@ -35,13 +35,13 @@ struct TrayCardRegressionTests {
   }
 
   @Test
-  func linkCardUsesBoundedPreviewWithSeparateTextRail() throws {
+  func linkCardUsesIntegratedFooterOverlay() throws {
     let source = try String(contentsOf: previewURL, encoding: .utf8)
 
-    #expect(source.contains("mediaHeight"))
-    #expect(source.contains("detailsBlock"))
-    #expect(source.contains(".frame(height: mediaHeight)"))
-    #expect(source.contains(".lineLimit(compact ? 2 : 3)"))
+    #expect(source.contains("footerBlock"))
+    #expect(source.contains("bottomShade"))
+    #expect(source.contains("alignment: .bottomLeading"))
+    #expect(source.contains("detailsBlock") == false)
     #expect(source.contains("preview.displayImage"))
     #expect(source.contains("chromeBar"))
   }


### PR DESCRIPTION
## Summary
- rebuild the link preview card as a single preview surface with an integrated footer gradient so the title and host stop collapsing into the bottom edge
- keep meaningful low-contrast webpage snapshots instead of filtering them out as blank artwork, while still falling back for truly empty captures
- cache the analyzed preview image in the snapshot model and add regressions for the compact footer layout plus low-contrast artwork retention

## Root Cause
The compact card split a very short preview area from the text rail, which left no protected bottom space for the title block. At the same time, the artwork analyzer treated subtle mostly-light webpage captures as disposable, so legitimate previews disappeared.

## Validation
- swift test
- ./script/build_and_run.sh --verify
- find Sources Tests -name '*.swift' -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 > 120 { print $1, $2; violations++ } END { print "violations", violations+0 }'
