### PR TITLE
[codex] Fix clip preview overflow

### DIFF
--- a/Sources/KClip/Views/ClipPreviewOverlayView.swift
+++ b/Sources/KClip/Views/ClipPreviewOverlayView.swift
@@ -9,11 +9,12 @@ struct ClipPreviewOverlayView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
       headerRow
-      previewBody
+      previewBody.frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .padding(20)
     .frame(width: 500, height: 246, alignment: .topLeading)
     .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(.regularMaterial))
+    .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
     .overlay(RoundedRectangle(cornerRadius: 24, style: .continuous).stroke(Color.white.opacity(0.10), lineWidth: 1))
     .onAppear { linkPreviews.warm([item]) }
   }

--- a/Tests/KClipTests/WebPagePreviewRegressionTests.swift
+++ b/Tests/KClipTests/WebPagePreviewRegressionTests.swift
@@ -15,6 +15,14 @@ struct WebPagePreviewRegressionTests {
     #expect(overlay.contains("openLink") || overlay.contains("NSWorkspace.shared.open"))
   }
 
+  @Test
+  func overlayClipsLargeSnapshotsToCardBounds() throws {
+    let overlay = try String(contentsOf: sourceURL("Sources/KClip/Views/ClipPreviewOverlayView.swift"), encoding: .utf8)
+
+    #expect(overlay.contains("previewBody.frame(maxWidth: .infinity, maxHeight: .infinity)"))
+    #expect(overlay.contains(".clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))"))
+  }
+
   private func sourceURL(_ path: String) -> URL {
     URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()


### PR DESCRIPTION
## Summary
- constrain the expanded clip preview body to the overlay card’s available space
- clip the overlay itself to the same rounded card shape so large webpage snapshots cannot draw past the visible block
- add a regression test that locks the overflow guard into the preview overlay source

## Root Cause
The preview overlay drew a rounded background but did not clip its content. After the recent single-surface preview refactor, a large WebKit snapshot could therefore render beyond the card even though the block itself looked bounded.

## Validation
- swift test
- ./script/build_and_run.sh --verify
- find Sources Tests -name '*.swift' -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 > 120 { print $1, $2; violations++ } END { print "violations", violations+0 }'
