### PR TITLE
[codex] Fix link preview spacing

### DIFF
--- a/Sources/KClip/Views/LinkPreviewSummaryView.swift
+++ b/Sources/KClip/Views/LinkPreviewSummaryView.swift
@@ -5,14 +5,15 @@ struct LinkPreviewSummaryView: View {
   let compact: Bool
 
   var body: some View {
-    VStack(alignment: .leading, spacing: compact ? 8 : 12) {
+    VStack(alignment: .leading, spacing: snapshotBottomGap) {
       snapshotBlock
       footerBlock
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
   }
 
-  private var snapshotHeight: CGFloat { compact ? 54 : 152 }
+  private var snapshotBottomGap: CGFloat { compact ? 10 : 16 }
+  private var snapshotHeight: CGFloat { compact ? 52 : 148 }
 
   private var snapshotBlock: some View {
     ZStack(alignment: .topLeading) {

--- a/Tests/KClipTests/TrayCardRegressionTests.swift
+++ b/Tests/KClipTests/TrayCardRegressionTests.swift
@@ -38,6 +38,8 @@ struct TrayCardRegressionTests {
   func linkCardUsesDedicatedSnapshotBlock() throws {
     let source = try String(contentsOf: previewURL, encoding: .utf8)
 
+    #expect(source.contains("snapshotBottomGap"))
+    #expect(source.contains("spacing: snapshotBottomGap"))
     #expect(source.contains("snapshotBlock"))
     #expect(source.contains("snapshotHeight"))
     #expect(source.contains(".frame(height: snapshotHeight)"))


### PR DESCRIPTION
## Summary
- add a dedicated bottom gap under the bounded link snapshot block
- rebalance the compact and expanded snapshot heights so the added space does not break the fixed card sizes
- lock the explicit snapshot gap into the tray card regression test

## Root Cause
The bounded snapshot block solved the overflow problem, but the layout still allocated almost all of the fixed card height to the block itself. That left the footer text visually glued to the block edge. The fix needs spacing and height to be adjusted together, not just one or the other.

## Validation
- swift test
- ./script/build_and_run.sh --verify
- find Sources Tests -name '*.swift' -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 > 120 { print $1, $2; violations++ } END { print "violations", violations+0 }'
