### PR TITLE
[codex] Fix link preview footer height

### DIFF
--- a/Sources/KClip/Views/LinkPreviewSummaryView.swift
+++ b/Sources/KClip/Views/LinkPreviewSummaryView.swift
@@ -13,7 +13,8 @@ struct LinkPreviewSummaryView: View {
   }
 
   private var snapshotBottomGap: CGFloat { compact ? 10 : 16 }
-  private var snapshotHeight: CGFloat { compact ? 52 : 148 }
+  private var footerHeight: CGFloat { compact ? 32 : 52 }
+  private var snapshotHeight: CGFloat { compact ? 42 : 100 }
 
   private var snapshotBlock: some View {
     ZStack(alignment: .topLeading) {
@@ -39,6 +40,7 @@ struct LinkPreviewSummaryView: View {
         .foregroundStyle(Color.white.opacity(0.60))
         .lineLimit(1)
     }
+    .frame(maxWidth: .infinity, minHeight: footerHeight, alignment: .topLeading)
   }
 
   private var badgeRow: some View {

--- a/Tests/KClipTests/TrayCardRegressionTests.swift
+++ b/Tests/KClipTests/TrayCardRegressionTests.swift
@@ -39,10 +39,12 @@ struct TrayCardRegressionTests {
     let source = try String(contentsOf: previewURL, encoding: .utf8)
 
     #expect(source.contains("snapshotBottomGap"))
+    #expect(source.contains("footerHeight"))
     #expect(source.contains("spacing: snapshotBottomGap"))
     #expect(source.contains("snapshotBlock"))
     #expect(source.contains("snapshotHeight"))
     #expect(source.contains(".frame(height: snapshotHeight)"))
+    #expect(source.contains(".frame(maxWidth: .infinity, minHeight: footerHeight, alignment: .topLeading)"))
     #expect(source.contains(".clipped()"))
     #expect(source.contains("footerBlock"))
     #expect(source.contains("preview.displayImage"))


### PR DESCRIPTION
## Summary
- reserve explicit footer height under the bounded snapshot block so the title and host lines stop clipping at the bottom edge
- reduce snapshot height to match the reserved footer space instead of forcing the footer to compress
- extend the tray card regression to lock in both the snapshot gap and the reserved footer frame

## Root Cause
The last layout change added gap under the preview block, but the footer itself still had no guaranteed height. When the card had to resolve the fixed vertical budget, SwiftUI compressed the footer text first, which is why the subtitle and lower edge were still getting cut off.

## Validation
- swift test
- ./script/build_and_run.sh --verify
- find Sources Tests -name '*.swift' -print0 | xargs -0 wc -l | awk '$2 != "total" && $1 > 120 { print $1, $2; violations++ } END { print "violations", violations+0 }'
