### PR TITLE
[codex] Add image clipboard support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added first-class image clipboard support for copied screenshots, photos, and image files.
+- Added automatic `Image` tagging, bounded image preview blocks, and image-aware paste/drag export.
+
 ## v0.1.0 · 2026-04-18
 
 - Initial public release of KClip for macOS.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
   <img src="assets/logo.svg" alt="KClip logo" width="160" />
 </p>
 
-KClip is a fast macOS menu bar clipboard history app focused on speed, polished motion, and local-only text storage.
+KClip is a fast macOS menu bar clipboard history app focused on speed, polished motion, and local-only clipboard storage.
 
 ## What It Does
 
 - Keeps a searchable clipboard history in the menu bar.
-- Stores text clips locally in Application Support.
+- Stores text and image clips locally in Application Support.
+- Auto-tags copied screenshots, photos, and image files as `Image`.
 - Supports tag filtering, pinning, preview, edit, delete, and reorder.
-- Pastes directly back into the previous app after selection.
-- Exports dragged clips as plain text or `.txt` files.
+- Pastes text or images directly back into the previous app after selection.
+- Exports dragged clips as plain text or `.txt` files, and image clips as `.png` files.
 
 ## Install From A Release
 

--- a/Sources/KClip/Models/ClipTag.swift
+++ b/Sources/KClip/Models/ClipTag.swift
@@ -27,8 +27,9 @@ enum ClipTag: String, Codable, CaseIterable, Identifiable {
   static var trayCases: [ClipTag] { [.pinned, .code, .link, .note, .color, .image] }
   static var assignableCases: [ClipTag] { trayCases.filter(\.isAssignable) }
 
-  static func inferredTags(for text: String) -> [ClipTag] {
+  static func inferredTags(for text: String, includesImage: Bool = false) -> [ClipTag] {
     var tags: [ClipTag] = [.general]
+    if includesImage { tags.append(.image) }
     let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
     let lower = trimmed.lowercased()
     if LinkTextClassifier.url(in: trimmed) != nil { tags.append(.link) }

--- a/Sources/KClip/Models/ClipboardItem+Content.swift
+++ b/Sources/KClip/Models/ClipboardItem+Content.swift
@@ -1,0 +1,11 @@
+import AppKit
+
+extension ClipboardItem {
+  var isImage: Bool { imageData != nil }
+  var isEditable: Bool { plainText != nil }
+
+  var previewImage: NSImage? {
+    guard let imageData else { return nil }
+    return NSImage(data: imageData)
+  }
+}

--- a/Sources/KClip/Models/ClipboardItem+ImageInit.swift
+++ b/Sources/KClip/Models/ClipboardItem+ImageInit.swift
@@ -1,0 +1,33 @@
+import Foundation
+import CoreGraphics
+
+extension ClipboardItem {
+  init(
+    imageData: Data,
+    imageSize: CGSize? = nil,
+    id: UUID = UUID(),
+    capturedAt: Date = .now,
+    sourceAppName: String? = nil,
+    sourceBundleID: String? = nil,
+    manualTags: [ClipTag] = [],
+    suppressedTags: [ClipTag] = [],
+    isPinned: Bool = false
+  ) {
+    self.init(
+      id: id,
+      text: Self.imageLabel(for: imageSize),
+      imageData: imageData,
+      capturedAt: capturedAt,
+      sourceAppName: sourceAppName,
+      sourceBundleID: sourceBundleID,
+      manualTags: manualTags,
+      suppressedTags: suppressedTags,
+      isPinned: isPinned
+    )
+  }
+
+  private static func imageLabel(for size: CGSize?) -> String {
+    guard let size else { return "Image" }
+    return "Image \(Int(size.width.rounded()))×\(Int(size.height.rounded()))"
+  }
+}

--- a/Sources/KClip/Models/ClipboardItem+Link.swift
+++ b/Sources/KClip/Models/ClipboardItem+Link.swift
@@ -1,6 +1,6 @@
 import Foundation
 
 extension ClipboardItem {
-  var linkURL: URL? { LinkTextClassifier.url(in: text) }
+  var linkURL: URL? { plainText.flatMap(LinkTextClassifier.url(in:)) }
   var isLink: Bool { linkURL != nil }
 }

--- a/Sources/KClip/Models/ClipboardItem+TagState.swift
+++ b/Sources/KClip/Models/ClipboardItem+TagState.swift
@@ -17,13 +17,16 @@ extension ClipboardItem {
   }
 
   func updating(text: String) -> ClipboardItem {
-    ClipboardItem(
+    guard plainText != nil else { return self }
+    return ClipboardItem(
       id: id,
       text: text,
+      plainText: text,
+      imageData: imageData,
       capturedAt: capturedAt,
       sourceAppName: sourceAppName,
       sourceBundleID: sourceBundleID,
-      suggestedTags: ClipTag.inferredTags(for: text),
+      suggestedTags: ClipTag.inferredTags(for: text, includesImage: imageData != nil),
       manualTags: manualTags,
       suppressedTags: suppressedTags,
       isPinned: isPinned
@@ -34,6 +37,8 @@ extension ClipboardItem {
     ClipboardItem(
       id: id,
       text: text,
+      plainText: plainText,
+      imageData: imageData,
       capturedAt: capturedAt,
       sourceAppName: sourceAppName,
       sourceBundleID: sourceBundleID,
@@ -50,6 +55,8 @@ extension ClipboardItem {
     return ClipboardItem(
       id: id,
       text: text,
+      plainText: plainText,
+      imageData: imageData,
       capturedAt: capturedAt,
       sourceAppName: sourceAppName,
       sourceBundleID: sourceBundleID,
@@ -61,9 +68,11 @@ extension ClipboardItem {
   }
 
   func resettingTags() -> ClipboardItem {
-    ClipboardItem(
+    return ClipboardItem(
       id: id,
       text: text,
+      plainText: plainText,
+      imageData: imageData,
       capturedAt: capturedAt,
       sourceAppName: sourceAppName,
       sourceBundleID: sourceBundleID,

--- a/Sources/KClip/Models/ClipboardItem.swift
+++ b/Sources/KClip/Models/ClipboardItem.swift
@@ -3,6 +3,8 @@ import Foundation
 struct ClipboardItem: Codable, Identifiable, Equatable {
   let id: UUID
   let text: String
+  let plainText: String?
+  let imageData: Data?
   let capturedAt: Date
   let sourceAppName: String?
   let sourceBundleID: String?
@@ -14,6 +16,8 @@ struct ClipboardItem: Codable, Identifiable, Equatable {
   enum CodingKeys: String, CodingKey {
     case id
     case text
+    case plainText
+    case imageData
     case capturedAt
     case sourceAppName
     case sourceBundleID
@@ -27,6 +31,8 @@ struct ClipboardItem: Codable, Identifiable, Equatable {
   init(
     id: UUID = UUID(),
     text: String,
+    plainText: String? = nil,
+    imageData: Data? = nil,
     capturedAt: Date = .now,
     sourceAppName: String? = nil,
     sourceBundleID: String? = nil,
@@ -37,10 +43,13 @@ struct ClipboardItem: Codable, Identifiable, Equatable {
   ) {
     self.id = id
     self.text = text
+    self.plainText = imageData == nil ? (plainText ?? text) : nil
+    self.imageData = imageData
     self.capturedAt = capturedAt
     self.sourceAppName = sourceAppName
     self.sourceBundleID = sourceBundleID
-    self.suggestedTags = Self.normalized(suggestedTags ?? ClipTag.inferredTags(for: text))
+    let baseTags = ClipTag.inferredTags(for: self.plainText ?? text, includesImage: imageData != nil)
+    self.suggestedTags = Self.normalized((suggestedTags ?? baseTags) + baseTags)
     self.manualTags = Self.normalized(manualTags)
     self.suppressedTags = Self.normalized(suppressedTags)
     self.isPinned = isPinned
@@ -50,14 +59,17 @@ struct ClipboardItem: Codable, Identifiable, Equatable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(UUID.self, forKey: .id)
     text = try container.decode(String.self, forKey: .text)
+    imageData = try container.decodeIfPresent(Data.self, forKey: .imageData)
+    let storedPlainText = try container.decodeIfPresent(String.self, forKey: .plainText)
+    plainText = imageData == nil ? (storedPlainText ?? text) : storedPlainText
     capturedAt = try container.decode(Date.self, forKey: .capturedAt)
     sourceAppName = try container.decodeIfPresent(String.self, forKey: .sourceAppName)
     sourceBundleID = try container.decodeIfPresent(String.self, forKey: .sourceBundleID)
     isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
     let legacyTags = try container.decodeIfPresent([ClipTag].self, forKey: .tags)
-    suggestedTags = Self.normalized(
-      try container.decodeIfPresent([ClipTag].self, forKey: .suggestedTags) ?? legacyTags ?? [.general]
-    )
+    let decodedTags = try container.decodeIfPresent([ClipTag].self, forKey: .suggestedTags) ?? legacyTags ?? []
+    let baseTags = ClipTag.inferredTags(for: plainText ?? text, includesImage: imageData != nil)
+    suggestedTags = Self.normalized(decodedTags + baseTags)
     manualTags = Self.normalized(try container.decodeIfPresent([ClipTag].self, forKey: .manualTags) ?? [])
     suppressedTags = Self.normalized(
       try container.decodeIfPresent([ClipTag].self, forKey: .suppressedTags) ?? []
@@ -68,6 +80,8 @@ struct ClipboardItem: Codable, Identifiable, Equatable {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(id, forKey: .id)
     try container.encode(text, forKey: .text)
+    try container.encodeIfPresent(plainText, forKey: .plainText)
+    try container.encodeIfPresent(imageData, forKey: .imageData)
     try container.encode(capturedAt, forKey: .capturedAt)
     try container.encodeIfPresent(sourceAppName, forKey: .sourceAppName)
     try container.encodeIfPresent(sourceBundleID, forKey: .sourceBundleID)

--- a/Sources/KClip/Services/ClipExportService.swift
+++ b/Sources/KClip/Services/ClipExportService.swift
@@ -3,7 +3,7 @@ import UniformTypeIdentifiers
 
 enum ClipExportService {
   static func itemProvider(for item: ClipboardItem) -> NSItemProvider {
-    let provider = NSItemProvider(object: item.text as NSString)
+    let provider = item.isImage ? NSItemProvider() : NSItemProvider(object: item.text as NSString)
     provider.suggestedName = suggestedFileName(for: item)
     provider.registerDataRepresentation(
       forTypeIdentifier: ClipCardDragPayload.contentType.identifier,
@@ -12,8 +12,14 @@ enum ClipExportService {
       completion(ClipCardDragPayload.data(for: item), nil)
       return nil
     }
+    if let imageData = item.imageData {
+      provider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+        completion(imageData, nil)
+        return nil
+      }
+    }
     provider.registerFileRepresentation(
-      forTypeIdentifier: UTType.plainText.identifier,
+      forTypeIdentifier: item.isImage ? UTType.png.identifier : UTType.plainText.identifier,
       fileOptions: [],
       visibility: .all
     ) { completion in
@@ -28,21 +34,26 @@ enum ClipExportService {
   }
 
   static func suggestedFileName(for item: ClipboardItem) -> String {
-    let head = item.text.split(whereSeparator: \.isNewline).first.map(String.init) ?? ""
-    let cleaned = head
-      .replacingOccurrences(of: #"[\\/:*?"<>|]+"#, with: " ", options: .regularExpression)
-      .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    let base = String((cleaned.isEmpty ? "KClip Clip" : cleaned).prefix(40)).trimmingCharacters(in: .whitespaces)
-    return "\(base).txt"
+    if item.isImage { return "\(cleanedBaseName(for: item.text).replacingOccurrences(of: "×", with: "x")).png" }
+    return "\(cleanedBaseName(for: item.text)).txt"
   }
 
   static func writeTemporaryFile(for item: ClipboardItem, directory: URL = exportDirectory) throws -> URL {
     let sessionDirectory = directory.appending(path: UUID().uuidString, directoryHint: .isDirectory)
     try FileManager.default.createDirectory(at: sessionDirectory, withIntermediateDirectories: true)
     let fileURL = sessionDirectory.appending(path: suggestedFileName(for: item))
-    try item.text.write(to: fileURL, atomically: true, encoding: .utf8)
+    if let imageData = item.imageData { try imageData.write(to: fileURL, options: .atomic) }
+    else { try item.text.write(to: fileURL, atomically: true, encoding: .utf8) }
     return fileURL
+  }
+
+  private static func cleanedBaseName(for text: String) -> String {
+    let head = text.split(whereSeparator: \.isNewline).first.map(String.init) ?? ""
+    let cleaned = head
+      .replacingOccurrences(of: #"[\\/:*?"<>|]+"#, with: " ", options: .regularExpression)
+      .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    return String((cleaned.isEmpty ? "KClip Clip" : cleaned).prefix(40)).trimmingCharacters(in: .whitespaces)
   }
 
   private static var exportDirectory: URL {

--- a/Sources/KClip/Services/ClipboardCaptureReader.swift
+++ b/Sources/KClip/Services/ClipboardCaptureReader.swift
@@ -1,0 +1,39 @@
+import AppKit
+import UniformTypeIdentifiers
+
+enum ClipboardCapture {
+  case text(String)
+  case image(Data)
+}
+
+enum ClipboardCaptureReader {
+  static func capture(from pasteboard: NSPasteboard) -> ClipboardCapture? {
+    if let imageData = imageData(from: pasteboard) { return .image(imageData) }
+    if let text = pasteboard.string(forType: .string) { return .text(text) }
+    return nil
+  }
+
+  private static func imageData(from pasteboard: NSPasteboard) -> Data? {
+    if let png = pasteboard.data(forType: .png) { return png }
+    if let tiff = pasteboard.data(forType: .tiff), let png = pngData(from: tiff) { return png }
+    if let image = pasteboard.readObjects(forClasses: [NSImage.self], options: nil)?.first as? NSImage {
+      return pngData(from: image)
+    }
+    let urls = pasteboard.readObjects(forClasses: [NSURL.self], options: nil) as? [URL] ?? []
+    guard let url = urls.first(where: isImageFile), let image = NSImage(contentsOf: url) else { return nil }
+    return pngData(from: image)
+  }
+
+  private static func isImageFile(_ url: URL) -> Bool {
+    UTType(filenameExtension: url.pathExtension)?.conforms(to: .image) == true
+  }
+
+  private static func pngData(from tiff: Data) -> Data? {
+    NSBitmapImageRep(data: tiff)?.representation(using: .png, properties: [:])
+  }
+
+  private static func pngData(from image: NSImage) -> Data? {
+    guard let tiff = image.tiffRepresentation else { return nil }
+    return pngData(from: tiff)
+  }
+}

--- a/Sources/KClip/Services/ClipboardMonitor.swift
+++ b/Sources/KClip/Services/ClipboardMonitor.swift
@@ -35,8 +35,14 @@ final class ClipboardMonitor {
   private func captureIfNeeded() {
     guard pasteboard.changeCount != changeCount else { return }
     changeCount = pasteboard.changeCount
-    guard let text = pasteboard.string(forType: .string) else { return }
     let source = applicationTracker.currentTarget()
-    store.record(text: text, sourceAppName: source?.localizedName, sourceBundleID: source?.bundleIdentifier)
+    switch ClipboardCaptureReader.capture(from: pasteboard) {
+    case .text(let text):
+      store.record(text: text, sourceAppName: source?.localizedName, sourceBundleID: source?.bundleIdentifier)
+    case .image(let data):
+      store.record(imageData: data, sourceAppName: source?.localizedName, sourceBundleID: source?.bundleIdentifier)
+    case nil:
+      return
+    }
   }
 }

--- a/Sources/KClip/Services/PasteActionService.swift
+++ b/Sources/KClip/Services/PasteActionService.swift
@@ -4,13 +4,16 @@ import Quartz
 
 struct PasteActionService {
   var writeText: (String) -> Void
+  var writeImage: (Data) -> Void
   var sendPaste: () -> Void
 
   init(
     writeText: @escaping (String) -> Void = PasteActionService.defaultWriteText,
+    writeImage: @escaping (Data) -> Void = PasteActionService.defaultWriteImage,
     sendPaste: @escaping () -> Void = PasteActionService.defaultSendPaste
   ) {
     self.writeText = writeText
+    self.writeImage = writeImage
     self.sendPaste = sendPaste
   }
 
@@ -22,6 +25,20 @@ struct PasteActionService {
 
     writeText(text)
     return true
+  }
+
+  @discardableResult
+  func preparePaste(imageData: Data) -> Bool {
+    guard imageData.isEmpty == false else { return false }
+    writeImage(imageData)
+    return true
+  }
+
+  @discardableResult
+  func preparePaste(item: ClipboardItem) -> Bool {
+    if let plainText = item.plainText { return preparePaste(text: plainText) }
+    guard let imageData = item.imageData else { return false }
+    return preparePaste(imageData: imageData)
   }
 
   func sendPreparedPaste() {
@@ -36,10 +53,23 @@ struct PasteActionService {
     return true
   }
 
+  @discardableResult
+  func performPaste(item: ClipboardItem) -> Bool {
+    guard preparePaste(item: item) else { return false }
+    sendPreparedPaste()
+    return true
+  }
+
   private static func defaultWriteText(_ text: String) {
     let pasteboard = NSPasteboard.general
     pasteboard.clearContents()
     pasteboard.setString(text, forType: .string)
+  }
+
+  private static func defaultWriteImage(_ data: Data) {
+    let pasteboard = NSPasteboard.general
+    pasteboard.clearContents()
+    pasteboard.setData(data, forType: .png)
   }
 
   private static func defaultSendPaste() {

--- a/Sources/KClip/Services/TrayPanelController+Interaction.swift
+++ b/Sources/KClip/Services/TrayPanelController+Interaction.swift
@@ -20,10 +20,10 @@ extension TrayPanelController {
       return
     }
     permissionGuide.hide()
-    guard pasteService.preparePaste(text: item.text) else { return }
+    guard pasteService.preparePaste(item: item) else { return }
     store.promoteAfterPaste(id: item.id)
     let targetBundleID = previousApplication?.bundleIdentifier
-    DebugTrace.write("paste target=\(targetBundleID ?? "nil") text=\(item.text.prefix(24))")
+    DebugTrace.write("paste target=\(targetBundleID ?? "nil") clip=\(item.primaryTag.title) \(item.text.prefix(24))")
     closeAndReturnToPrevious()
     handoff.sendWhenReady(targetBundleID: targetBundleID, activateTarget: { [weak self] in
       self?.previousApplication?.activate(options: [.activateAllWindows])

--- a/Sources/KClip/Stores/ClipboardStore+Record.swift
+++ b/Sources/KClip/Stores/ClipboardStore+Record.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension ClipboardStore {
+  func record(text: String, sourceAppName: String? = nil, sourceBundleID: String? = nil) {
+    let normalizedText = normalized(text)
+    guard normalizedText.isEmpty == false, firstRegularItem?.plainText != normalizedText else { return }
+    record(ClipboardItem(text: normalizedText, sourceAppName: sourceAppName, sourceBundleID: sourceBundleID))
+  }
+
+  func record(imageData: Data, sourceAppName: String? = nil, sourceBundleID: String? = nil) {
+    guard imageData.isEmpty == false, firstRegularItem?.imageData != imageData else { return }
+    record(ClipboardItem(imageData: imageData, sourceAppName: sourceAppName, sourceBundleID: sourceBundleID))
+  }
+
+  func record(_ item: ClipboardItem) {
+    items.insert(item, at: regularStartIndex)
+    trimIfNeeded()
+    persist()
+  }
+
+  func normalized(_ text: String) -> String { text.trimmingCharacters(in: .whitespacesAndNewlines) }
+  var regularStartIndex: Int { items.firstIndex(where: { $0.isPinned == false }) ?? items.count }
+  var firstRegularItem: ClipboardItem? { items.indices.contains(regularStartIndex) ? items[regularStartIndex] : nil }
+  func trimIfNeeded() { if items.count > limit { items = Array(items.prefix(limit)) } }
+
+  func persist() {
+    let snapshot = items
+    let fileURL = fileURL
+    persistenceQueue.async {
+      do {
+        let directoryURL = fileURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let data = try JSONEncoder().encode(snapshot)
+        try data.write(to: fileURL, options: .atomic)
+      } catch {}
+    }
+  }
+}

--- a/Sources/KClip/Stores/ClipboardStore.swift
+++ b/Sources/KClip/Stores/ClipboardStore.swift
@@ -3,25 +3,14 @@ import Observation
 
 @Observable
 final class ClipboardStore {
-  private(set) var items: [ClipboardItem] = []
-  private let fileURL: URL
-  private let limit: Int
-  private let persistenceQueue = DispatchQueue(label: "com.kuekhaoyang.kclip.persistence", qos: .utility)
+  var items: [ClipboardItem] = []
+  let fileURL: URL
+  let limit: Int
+  let persistenceQueue = DispatchQueue(label: "com.kuekhaoyang.kclip.persistence", qos: .utility)
 
   init(fileURL: URL, limit: Int = 100) {
     self.fileURL = fileURL
     self.limit = limit
-  }
-
-  func record(text: String, sourceAppName: String? = nil, sourceBundleID: String? = nil) {
-    let normalizedText = normalized(text)
-    guard normalizedText.isEmpty == false, firstRegularItem?.text != normalizedText else { return }
-    items.insert(
-      ClipboardItem(text: normalizedText, sourceAppName: sourceAppName, sourceBundleID: sourceBundleID),
-      at: regularStartIndex
-    )
-    trimIfNeeded()
-    persist()
   }
 
   func delete(id: UUID) { mutateItem(id: id) { _ in nil } }
@@ -89,23 +78,5 @@ final class ClipboardStore {
     let destination = max(0, min(from < toOffset ? toOffset - 1 : toOffset, laneItems.count))
     laneItems.insert(movingItem, at: destination)
     return laneItems
-  }
-
-  private func normalized(_ text: String) -> String { text.trimmingCharacters(in: .whitespacesAndNewlines) }
-  private var regularStartIndex: Int { items.firstIndex(where: { $0.isPinned == false }) ?? items.count }
-  private var firstRegularItem: ClipboardItem? { items.indices.contains(regularStartIndex) ? items[regularStartIndex] : nil }
-  private func trimIfNeeded() { if items.count > limit { items = Array(items.prefix(limit)) } }
-
-  private func persist() {
-    let snapshot = items
-    let fileURL = fileURL
-    persistenceQueue.async {
-      do {
-        let directoryURL = fileURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-        let data = try JSONEncoder().encode(snapshot)
-        try data.write(to: fileURL, options: .atomic)
-      } catch {}
-    }
   }
 }

--- a/Sources/KClip/Views/ClipCardContextMenu.swift
+++ b/Sources/KClip/Views/ClipCardContextMenu.swift
@@ -12,7 +12,7 @@ struct ClipCardContextMenu: View {
   var body: some View {
     Group {
       Button("Preview", action: previewItem)
-      Button("Edit Clip", action: editItem)
+      if item.isEditable { Button("Edit Clip", action: editItem) }
       Button(item.isPinned ? "Unpin This" : "Pin This", action: pinItem)
       Menu("Manage Tags") {
         ForEach(ClipTag.assignableCases) { tag in

--- a/Sources/KClip/Views/ClipPreviewOverlayView.swift
+++ b/Sources/KClip/Views/ClipPreviewOverlayView.swift
@@ -12,7 +12,7 @@ struct ClipPreviewOverlayView: View {
       previewBody.frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .padding(20)
-    .frame(width: 500, height: 246, alignment: .topLeading)
+    .frame(width: overlaySize.width, height: overlaySize.height, alignment: .topLeading)
     .background(RoundedRectangle(cornerRadius: 24, style: .continuous).fill(.regularMaterial))
     .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
     .overlay(RoundedRectangle(cornerRadius: 24, style: .continuous).stroke(Color.white.opacity(0.10), lineWidth: 1))
@@ -33,7 +33,9 @@ struct ClipPreviewOverlayView: View {
 
   @ViewBuilder
   private var previewBody: some View {
-    if let preview = linkPreviews.model(for: item) {
+    if item.isImage {
+      ImagePreviewSummaryView(item: item, compact: false)
+    } else if let preview = linkPreviews.model(for: item) {
       LinkPreviewSummaryView(preview: preview, compact: false)
     } else {
       ScrollView {
@@ -53,5 +55,9 @@ struct ClipPreviewOverlayView: View {
   private func openLink() {
     guard let url = item.linkURL else { return }
     NSWorkspace.shared.open(url)
+  }
+
+  private var overlaySize: CGSize {
+    item.isImage ? CGSize(width: 560, height: 262) : CGSize(width: 500, height: 246)
   }
 }

--- a/Sources/KClip/Views/ImagePreviewSummaryView.swift
+++ b/Sources/KClip/Views/ImagePreviewSummaryView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct ImagePreviewSummaryView: View {
+  let item: ClipboardItem
+  let compact: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: compact ? 10 : 14) {
+      mediaBlock
+      VStack(alignment: .leading, spacing: compact ? 3 : 5) {
+        Text(item.text)
+          .font(.system(size: compact ? 12 : 16, weight: .bold, design: .rounded))
+          .lineLimit(compact ? 1 : 2)
+        Text(item.sourceLine ?? "Clipboard image")
+          .font(.system(size: compact ? 10 : 12, weight: .semibold, design: .rounded))
+          .foregroundStyle(Color.white.opacity(0.60))
+          .lineLimit(1)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .animation(.spring(response: 0.22, dampingFraction: 0.82), value: item.id)
+  }
+
+  private var mediaBlock: some View {
+    ZStack(alignment: .topLeading) {
+      LinearGradient(colors: [Color.white.opacity(0.12), Color.white.opacity(0.04)], startPoint: .topLeading, endPoint: .bottomTrailing)
+      if let image = item.previewImage {
+        Image(nsImage: image)
+          .resizable()
+          .scaledToFit()
+          .padding(compact ? 10 : 14)
+          .transition(.scale(scale: 0.98).combined(with: .opacity))
+      } else {
+        Image(systemName: "photo")
+          .font(.system(size: compact ? 22 : 34, weight: .semibold))
+          .foregroundStyle(Color.white.opacity(0.55))
+      }
+      badge
+    }
+    .frame(maxWidth: .infinity)
+    .frame(height: compact ? 54 : 152)
+    .clipShape(RoundedRectangle(cornerRadius: compact ? 16 : 22, style: .continuous))
+    .overlay(RoundedRectangle(cornerRadius: compact ? 16 : 22, style: .continuous).stroke(Color.white.opacity(0.08), lineWidth: 1))
+  }
+
+  private var badge: some View {
+    Label("Image", systemImage: "photo")
+      .font(.system(size: compact ? 10 : 11, weight: .bold, design: .rounded))
+      .padding(.horizontal, compact ? 9 : 11)
+      .padding(.vertical, compact ? 6 : 7)
+      .background(Capsule().fill(Color.black.opacity(0.18)))
+      .padding(compact ? 10 : 12)
+  }
+}

--- a/Sources/KClip/Views/TrayCardTagColor.swift
+++ b/Sources/KClip/Views/TrayCardTagColor.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+extension ClipboardItem {
+  var trayCardTagColor: Color {
+    switch primaryTag {
+    case .pinned: Color(red: 0.98, green: 0.80, blue: 0.46)
+    case .general: Color.white.opacity(0.72)
+    case .code: Color(red: 0.58, green: 0.78, blue: 1.00)
+    case .link: Color(red: 0.58, green: 0.90, blue: 0.94)
+    case .note: Color(red: 0.66, green: 0.90, blue: 0.70)
+    case .color: Color(red: 1.00, green: 0.78, blue: 0.46)
+    case .image: Color(red: 0.96, green: 0.72, blue: 0.86)
+    }
+  }
+}

--- a/Sources/KClip/Views/TrayCardView.swift
+++ b/Sources/KClip/Views/TrayCardView.swift
@@ -29,7 +29,10 @@ struct TrayCardView: View {
 
   @ViewBuilder
   private var contentBlock: some View {
-    if let preview = linkPreviews.model(for: item) {
+    if item.isImage {
+      ImagePreviewSummaryView(item: item, compact: true)
+        .frame(maxWidth: .infinity, minHeight: 88, maxHeight: 88, alignment: .topLeading)
+    } else if let preview = linkPreviews.model(for: item) {
       LinkPreviewSummaryView(preview: preview, compact: true)
         .frame(maxWidth: .infinity, minHeight: 88, maxHeight: 88, alignment: .topLeading)
     } else {
@@ -46,7 +49,7 @@ struct TrayCardView: View {
     HStack(alignment: .firstTextBaseline, spacing: 10) {
       Text(item.primaryTag.title)
         .font(.system(size: 10, weight: .bold, design: .rounded))
-        .foregroundStyle(tagColor)
+        .foregroundStyle(item.trayCardTagColor)
       Spacer(minLength: 0)
       if item.isPinned { pinMark }
       Text(item.capturedAt.relativeClipTimestamp())
@@ -101,17 +104,5 @@ struct TrayCardView: View {
 
   private var shadowColor: Color {
     .black.opacity(isSelected ? 0.14 : 0.07)
-  }
-
-  private var tagColor: Color {
-    switch item.primaryTag {
-    case .pinned: Color(red: 0.98, green: 0.80, blue: 0.46)
-    case .general: Color.white.opacity(0.72)
-    case .code: Color(red: 0.58, green: 0.78, blue: 1.00)
-    case .link: Color(red: 0.58, green: 0.90, blue: 0.94)
-    case .note: Color(red: 0.66, green: 0.90, blue: 0.70)
-    case .color: Color(red: 1.00, green: 0.78, blue: 0.46)
-    case .image: Color(red: 0.96, green: 0.72, blue: 0.86)
-    }
   }
 }

--- a/Sources/KClip/Views/TrayPanelRootView+Actions.swift
+++ b/Sources/KClip/Views/TrayPanelRootView+Actions.swift
@@ -31,9 +31,10 @@ extension TrayPanelRootView {
   }
 
   func beginEditing(_ item: ClipboardItem) {
+    guard item.isEditable else { return }
     withAnimation(.spring(response: 0.30, dampingFraction: 0.84)) {
       interaction.dismissPreview()
-      draftText = item.text
+      draftText = item.plainText ?? ""
       editingItem = item
     }
   }

--- a/Tests/KClipTests/ClipExportServiceTests.swift
+++ b/Tests/KClipTests/ClipExportServiceTests.swift
@@ -21,4 +21,16 @@ struct ClipExportServiceTests {
     #expect(fileURL.pathExtension == "txt")
     #expect(try String(contentsOf: fileURL, encoding: .utf8) == "line 1\nline 2")
   }
+
+  @Test
+  func temporaryExportFileContainsImageData() throws {
+    let directory = FileManager.default.temporaryDirectory.appending(path: UUID().uuidString)
+    let data = try samplePNGData()
+    let item = ClipboardItem(imageData: data)
+
+    let fileURL = try ClipExportService.writeTemporaryFile(for: item, directory: directory)
+
+    #expect(fileURL.pathExtension == "png")
+    #expect(try Data(contentsOf: fileURL) == data)
+  }
 }

--- a/Tests/KClipTests/ClipboardCaptureReaderTests.swift
+++ b/Tests/KClipTests/ClipboardCaptureReaderTests.swift
@@ -1,0 +1,39 @@
+import AppKit
+import Foundation
+import Testing
+@testable import KClip
+
+@Suite("ClipboardCaptureReaderTests")
+struct ClipboardCaptureReaderTests {
+  @Test
+  func capturesDirectPNGDataFromPasteboard() throws {
+    let pasteboard = NSPasteboard(name: .init(UUID().uuidString))
+    let data = try samplePNGData()
+    pasteboard.clearContents()
+    pasteboard.setData(data, forType: .png)
+
+    if case .image(let captured)? = ClipboardCaptureReader.capture(from: pasteboard) {
+      #expect(captured == data)
+    } else {
+      Issue.record("Expected image capture from PNG pasteboard data")
+    }
+  }
+
+  @Test
+  func capturesImageFilesCopiedFromFinderStylePasteboard() throws {
+    let pasteboard = NSPasteboard(name: .init(UUID().uuidString))
+    let url = FileManager.default.temporaryDirectory.appending(path: "\(UUID().uuidString).png")
+    let data = try samplePNGData()
+    let size = try #require(NSImage(data: data)?.size)
+    try data.write(to: url, options: .atomic)
+    pasteboard.clearContents()
+    pasteboard.writeObjects([url as NSURL])
+
+    if case .image(let captured)? = ClipboardCaptureReader.capture(from: pasteboard) {
+      #expect(captured.isEmpty == false)
+      #expect(NSImage(data: captured)?.size == size)
+    } else {
+      Issue.record("Expected image capture from copied image file URL")
+    }
+  }
+}

--- a/Tests/KClipTests/ClipboardItemTests.swift
+++ b/Tests/KClipTests/ClipboardItemTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 import Testing
 @testable import KClip
 
@@ -35,5 +36,16 @@ struct ClipboardItemTests {
 
     #expect(item.sourceAppName == "Safari")
     #expect(item.sourceBundleID == "com.apple.Safari")
+  }
+
+  @Test
+  func imageItemsKeepImageTagAndNoTextPayload() throws {
+    let item = ClipboardItem(imageData: try samplePNGData(), imageSize: CGSize(width: 96, height: 64))
+
+    #expect(item.isImage)
+    #expect(item.text == "Image 96×64")
+    #expect(item.plainText == nil)
+    #expect(item.tags == [ClipTag.general, .image])
+    #expect(item.linkURL == nil)
   }
 }

--- a/Tests/KClipTests/ImageClipboardStoreTests.swift
+++ b/Tests/KClipTests/ImageClipboardStoreTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import KClip
+
+@Suite("ImageClipboardStoreTests")
+struct ImageClipboardStoreTests {
+  @Test
+  func recordsAndPersistsImageClips() throws {
+    let url = tempURL()
+    let first = ClipboardStore(fileURL: url, limit: 5)
+    let data = try samplePNGData()
+    first.record(imageData: data)
+    try first.save()
+
+    let second = ClipboardStore(fileURL: url, limit: 5)
+    try second.load()
+
+    #expect(second.items.count == 1)
+    #expect(second.items[0].isImage)
+    #expect(second.items[0].imageData == data)
+    #expect(second.items[0].tags.contains(.image))
+  }
+
+  private func tempURL() -> URL {
+    FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString)
+      .appendingPathExtension("json")
+  }
+}

--- a/Tests/KClipTests/ImagePreviewRegressionTests.swift
+++ b/Tests/KClipTests/ImagePreviewRegressionTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@Suite("ImagePreviewRegressionTests")
+struct ImagePreviewRegressionTests {
+  @Test
+  func trayAndPreviewOverlayUseDedicatedImageSummaryBlocks() throws {
+    let card = try source("Sources/KClip/Views/TrayCardView.swift")
+    let overlay = try source("Sources/KClip/Views/ClipPreviewOverlayView.swift")
+    let summary = try source("Sources/KClip/Views/ImagePreviewSummaryView.swift")
+
+    #expect(card.contains("item.isImage"))
+    #expect(card.contains("ImagePreviewSummaryView"))
+    #expect(overlay.contains("item.isImage"))
+    #expect(overlay.contains("ImagePreviewSummaryView"))
+    #expect(summary.contains("clipShape"))
+    #expect(summary.contains("scaledToFit"))
+  }
+
+  private func source(_ path: String) throws -> String {
+    try String(contentsOf: rootURL.appending(path: path), encoding: .utf8)
+  }
+
+  private var rootURL: URL {
+    URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+      .deletingLastPathComponent()
+  }
+}

--- a/Tests/KClipTests/PasteActionServiceTests.swift
+++ b/Tests/KClipTests/PasteActionServiceTests.swift
@@ -20,10 +20,24 @@ struct PasteActionServiceTests {
     var called = false
     let service = PasteActionService(
       writeText: { _ in called = true },
+      writeImage: { _ in called = true },
       sendPaste: { called = true }
     )
 
     #expect(service.performPaste(text: "") == false)
     #expect(called == false)
+  }
+
+  @Test
+  func writesImageBeforeSendingPaste() throws {
+    var events: [String] = []
+    let service = PasteActionService(
+      writeText: { _ in events.append("text") },
+      writeImage: { _ in events.append("image") },
+      sendPaste: { events.append("paste") }
+    )
+
+    #expect(try service.performPaste(item: ClipboardItem(imageData: samplePNGData())))
+    #expect(events == ["image", "paste"])
   }
 }

--- a/Tests/KClipTests/TestImageFactory.swift
+++ b/Tests/KClipTests/TestImageFactory.swift
@@ -1,0 +1,22 @@
+import AppKit
+import Foundation
+
+func samplePNGData(size: NSSize = NSSize(width: 24, height: 16)) throws -> Data {
+  let image = NSImage(size: size)
+  image.lockFocus()
+  NSColor.systemPink.setFill()
+  NSBezierPath(rect: NSRect(origin: .zero, size: size)).fill()
+  image.unlockFocus()
+  guard
+    let tiff = image.tiffRepresentation,
+    let rep = NSBitmapImageRep(data: tiff),
+    let data = rep.representation(using: .png, properties: [:])
+  else {
+    throw TestImageFactoryError.encodingFailed
+  }
+  return data
+}
+
+enum TestImageFactoryError: Error {
+  case encodingFailed
+}

--- a/docs/superpowers/specs/2026-04-18-image-clipboard-design.md
+++ b/docs/superpowers/specs/2026-04-18-image-clipboard-design.md
@@ -1,0 +1,60 @@
+# KClip Image Clipboard Design
+
+## Goal
+
+Extend KClip from text-only history into mixed text and image history without breaking the fast tray flow.
+
+## Scope
+
+- Capture direct image clipboard data.
+- Capture copied image files from Finder-style pasteboards.
+- Auto-assign the `Image` tag to image clips.
+- Keep image previews bounded inside card and stage blocks.
+- Paste image clips back into target apps.
+- Export dragged image clips as `.png`.
+
+## UX Direction
+
+- Tray cards keep the existing compact card shell.
+- Image cards use a dedicated preview block instead of dumping metadata text into the card body.
+- The preview stage uses a larger bounded block than the tray card, but still stays inside the tray limits.
+- Motion stays restrained: existing tray springs remain, and image blocks fade/scale in subtly.
+
+## Data Model
+
+`ClipboardItem` now supports two payload shapes:
+
+- text clips: `text` plus `plainText`
+- image clips: `text` summary plus `imageData`
+
+Rules:
+
+- link detection only applies to `plainText`
+- image clips are not editable in the text editor flow
+- image clips always seed suggested tags with `Image`
+
+## Capture Rules
+
+- Prefer image payloads over text when the pasteboard exposes both.
+- Accept direct PNG/TIFF image clipboard content.
+- If the pasteboard contains copied file URLs, inspect them and load the first image file.
+- Normalize captured images into PNG data for storage and drag/export consistency.
+
+## Paste And Drag Rules
+
+- Text clips keep the existing pasteboard string path.
+- Image clips write PNG data to the pasteboard before triggering the synthetic paste event.
+- Dragging an image clip exposes both a PNG data representation and a PNG file representation.
+- Finder drops should materialize a file; rich input targets should receive image data directly.
+
+## Constraints
+
+- Keep every Swift source file at or under 120 lines.
+- Preserve local-only storage.
+- Do not regress link preview behavior for text clips.
+
+## Validation
+
+- `swift test`
+- `./script/build_and_run.sh --verify`
+- manual smoke check: copy screenshot, copy image file in Finder, paste both from KClip


### PR DESCRIPTION
## Summary
- add first-class image clipboard capture for direct image data and copied image files
- auto-tag image clips, preview them in bounded image blocks, and paste/export them as images
- update docs and add regression coverage for image capture, storage, preview, and export flows

## Why
KClip was text-only, so screenshots, photos, and copied image files were not preserved as usable clipboard history items.

## Validation
- swift test
- ./script/build_and_run.sh --verify